### PR TITLE
Added describe command

### DIFF
--- a/kubectl-commander
+++ b/kubectl-commander
@@ -204,9 +204,9 @@ krew optional plugin:
 |---------------|--------------------------------------------------------------|
 | ctrl-x        | Enter into container (for pods, deployments)                 |
 |---------------|--------------------------------------------------------------|
-| ctrl-d        | /!\\\\\ delete object /!\\\\\ (works with multi selection)           |
+| alt-d        | /!\\\\\ delete object /!\\\\\ (works with multi selection)    |
 |---------------|--------------------------------------------------------------|
-| ctrl-g        | describe Object															                 |
+| ctrl-d        | describe Object															                 |
 |---------------|--------------------------------------------------------------|
 | ctrl-e        | edit object                                                  |
 |---------------|--------------------------------------------------------------|
@@ -236,12 +236,12 @@ fzf -m -e --track --ansi +s $FZF_EXTRA_OPTIONS \
 	--prompt "$TYPE > " \
 	--bind="ctrl-h:change-preview(print \"$HELP\")+change-preview-window(right,<80(up)|hidden)+change-preview-label([ Help ])" \
 	--bind="ctrl-y:change-preview($PRINT_YAML | yq -C \${YQ:-.})+change-preview-window(right,wrap,<80(up,wrap)|up,wrap|hidden)+transform-preview-label:$PREVIEW_LABEL_YAML" \
-	--bind="ctrl-g:change-preview($PRINT_DESCRIBE)+change-preview-window(right,wrap,<80(up,wrap)|up,wrap|hidden)+transform-preview-label:[ Description ]" \
+	--bind="ctrl-d:change-preview($PRINT_DESCRIBE)+change-preview-window(right,wrap,<80(up,wrap)|up,wrap|hidden)+transform-preview-label:[ Description ]" \
 	--bind="ctrl-v:change-preview($PRINT_EVENTS)+change-preview-window(up,follow|up,80%,border-bottom,follow|hidden)+change-preview-label([ Events ])" \
 	--bind="ctrl-l:change-preview($PRINT_LOGS --tail=5000)+change-preview-window(up,follow|up,80%,border-bottom,follow|hidden)+change-preview-label([ Logs ])" \
 	--bind="ctrl-x:execute($EXEC_IN_POD)" \
 	--bind="alt-l:toggle-preview-wrap" \
-	--bind="ctrl-d:execute(echo; for item in {+$NAME_FIELD}; do echo \$item; done; echo \"\n * /!\ delete selected items (y/N) ? *\"; read ANSW; [[ \$ANSW == \"y\" ]] && $DELETE)" \
+	--bind="alt-d:execute(echo; for item in {+$NAME_FIELD}; do echo \$item; done; echo \"\n * /!\ delete selected items (y/N) ? *\"; read ANSW; [[ \$ANSW == \"y\" ]] && $DELETE)" \
 	--bind="ctrl-e:execute($EDIT)" \
 	--bind="ctrl-s:execute($EDIT_SECRET)" \
 	--bind="ctrl-a:select-all" \

--- a/kubectl-commander
+++ b/kubectl-commander
@@ -145,6 +145,7 @@ export FZF_DEFAULT_COMMAND="$k8cmd get $TYPE $PARAMETERS"
 PRINT_YAML="[[ -f /tmp/yq ]] && YQ=\$(cat /tmp/yq); $k8cmd get $([ "$MULTI_TYPE" -eq 0 ] && echo $TYPE) {$NAME_FIELD} -o yaml $PREVIEW_PARAMETERS"
 PREVIEW_LABEL_YAML="[[ -f /tmp/yq ]] && echo [ YAML - yq \$(cat /tmp/yq) ] || echo [ YAML - yq .]"
 PRINT_EVENTS="$k8cmd events $PREVIEW_PARAMETERS -w --for=$([ "$MULTI_TYPE" -eq 0 ] && echo $TYPE/){$NAME_FIELD}"
+PRINT_DESCRIBE="$k8cmd describe $PREVIEW_PARAMETERS $(echo $TYPE/){$NAME_FIELD}"
 PRINT_LOGS="$k8cmd logs -f {$NAME_FIELD} $PREVIEW_PARAMETERS --all-containers"
 #PRINT_LOGS="$k8cmd stern --color always $PREVIEW_PARAMETERS {$NAME_FIELD}"
 EDIT="$k8cmd edit $([ "$MULTI_TYPE" -eq 0 ] && echo $TYPE) $PREVIEW_PARAMETERS {$NAME_FIELD} >/dev/tty"
@@ -205,6 +206,8 @@ krew optional plugin:
 |---------------|--------------------------------------------------------------|
 | ctrl-d        | /!\\\\\ delete object /!\\\\\ (works with multi selection)           |
 |---------------|--------------------------------------------------------------|
+| ctrl-g        | describe Object															                 |
+|---------------|--------------------------------------------------------------|
 | ctrl-e        | edit object                                                  |
 |---------------|--------------------------------------------------------------|
 | ctrl-s        | edit secret (decrypt/encrypt)                                |
@@ -233,6 +236,7 @@ fzf -m -e --track --ansi +s $FZF_EXTRA_OPTIONS \
 	--prompt "$TYPE > " \
 	--bind="ctrl-h:change-preview(print \"$HELP\")+change-preview-window(right,<80(up)|hidden)+change-preview-label([ Help ])" \
 	--bind="ctrl-y:change-preview($PRINT_YAML | yq -C \${YQ:-.})+change-preview-window(right,wrap,<80(up,wrap)|up,wrap|hidden)+transform-preview-label:$PREVIEW_LABEL_YAML" \
+	--bind="ctrl-g:change-preview($PRINT_DESCRIBE)+change-preview-window(right,wrap,<80(up,wrap)|up,wrap|hidden)+transform-preview-label:[ Description ]" \
 	--bind="ctrl-v:change-preview($PRINT_EVENTS)+change-preview-window(up,follow|up,80%,border-bottom,follow|hidden)+change-preview-label([ Events ])" \
 	--bind="ctrl-l:change-preview($PRINT_LOGS --tail=5000)+change-preview-window(up,follow|up,80%,border-bottom,follow|hidden)+change-preview-label([ Logs ])" \
 	--bind="ctrl-x:execute($EXEC_IN_POD)" \


### PR DESCRIPTION
Added a binding to run `kubectl describe` and display the output for the selected object. I find it useful for some object types such as HPA's. In the future it may be worth adding colorization to the output, but there are already separate plugins for that out there. 

![image](https://github.com/user-attachments/assets/423447e5-f27e-4ee6-8ca7-36ae4e00ab5d)

